### PR TITLE
remove jedi geovals due to memory issue on orion

### DIFF
--- a/src/gsi/genstats_gps.f90
+++ b/src/gsi/genstats_gps.f90
@@ -54,14 +54,6 @@ module m_gpsStats
       real(r_kind)    :: loc                    
       real(r_kind)    :: type               
 
-      real(r_kind),dimension(:),pointer :: tsenges
-      real(r_kind),dimension(:),pointer :: tvirges
-      real(r_kind),dimension(:),pointer :: sphmges
-      real(r_kind),dimension(:),pointer :: prsiges
-      real(r_kind),dimension(:),pointer :: prslges
-      real(r_kind),dimension(:),pointer :: hgtiges
-      real(r_kind),dimension(:),pointer :: hgtlges
-
       real(r_kind),dimension(:),pointer :: rdiag => NULL()
       integer(i_kind) :: kprof
       logical         :: luse          !  flag indicating if ob is used in pen.
@@ -814,13 +806,6 @@ subroutine contents_netcdf_diag_
 
 !          geovals
            call nc_diag_metadata("surface_altitude",          sngl(gps_allptr%rdiag(9)) )
-           call nc_diag_data2d("air_temperature",             sngl(gps_allptr%tsenges) )
-           call nc_diag_data2d("virtual_temperature",         sngl(gps_allptr%tvirges) )
-           call nc_diag_data2d("specific_humidity",           sngl(gps_allptr%sphmges) )
-           call nc_diag_data2d("geopotential_height",         sngl(gps_allptr%hgtlges) )
-           call nc_diag_data2d("geopotential_height_levels",  sngl(gps_allptr%hgtiges) )
-           call nc_diag_data2d("air_pressure",                sngl(gps_allptr%prslges) )
-           call nc_diag_data2d("air_pressure_levels",         sngl(gps_allptr%prsiges) )
 
            if (save_jacobian) then
               call readarray(dhx_dx, gps_allptr%rdiag(ioff+1:nreal))

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -383,6 +383,8 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   real(r_kind),allocatable,dimension(:) :: rlat_hil,rlon_hil,height,wtob,wght_hilb
 ! end of block
 
+! H. ZHANG 20210113
+  real(r_kind) time_launch
 
 !  equivalence to handle character names
   equivalence(r_prvstg(1,1),c_prvstg) 
@@ -472,15 +474,21 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
             tcamtob .or. lcbasob .or. cldchob
   aircraftobst=.false.
   if(tob)then
-     nreal=25
-  else if(uvob) then 
+! H. ZHANG 20210113
+!    nreal=25
      nreal=26
+  else if(uvob) then 
+!    nreal=26
+     nreal=27
   else if(spdob) then
      nreal=24
   else if(psob) then
-     nreal=20
+!    nreal=20
+     nreal=21
   else if(qob) then
-     nreal=26
+!    nreal=26
+     nreal=27
+! H. ZHANG 20210113
   else if(pwob) then
      nreal=20
   else if(sstob) then
@@ -1820,6 +1828,8 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  endif
               end if
 
+              time_launch=-99999.0_r_kind ! H. ZHANG 20210113
+
 !             If needed, extract drift information.   
               if(driftl)then
                  if(drfdat(1,k) >= r360)drfdat(1,k)=drfdat(1,k)-r360
@@ -1841,6 +1851,10 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  time_drift = timeobs + time_correction
                  if (abs(time_drift-time)>four) time_drift = time
  
+! H. ZHANG 20210113
+                 time_launch=real(real(drfdat(3,1),r_single),r_double) + time_correction
+! H. ZHANG 20210113
+
 !                Check to see if the time is outside range
                  if (l4dvar.or.l4densvar) then
                     t4dv=toff+time_drift
@@ -2094,11 +2108,14 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(23,iout)=r_sprvstg(1,1)         ! subprovider name
                  cdata_all(24,iout)=obsdat(10,k)           ! cat
                  cdata_all(25,iout)=var_jb(3,k)            ! non linear qc for T
+! H. ZHANG 20210113
+                 cdata_all(26,iout)=time_launch
                  if (aircraft_t_bc_pof .or. aircraft_t_bc .or.aircraft_t_bc_ext) then
-                    cdata_all(26,iout)=aircraftwk(1,k)     ! phase of flight
-                    cdata_all(27,iout)=aircraftwk(2,k)     ! vertical velocity
-                    cdata_all(28,iout)=idx                 ! index of temperature bias
+                    cdata_all(27,iout)=aircraftwk(1,k)     ! phase of flight
+                    cdata_all(28,iout)=aircraftwk(2,k)     ! vertical velocity
+                    cdata_all(29,iout)=idx                 ! index of temperature bias
                  end if
+! H. ZHANG 20210113
                  if(perturb_obs)cdata_all(nreal,iout)=ran01dom()*perturb_fact ! t perturbation
                  if (twodvar_regional) &
                     call adjust_error(cdata_all(17,iout),cdata_all(18,iout),cdata_all(11,iout),cdata_all(1,iout))
@@ -2227,10 +2244,14 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(24,iout)=obsdat(10,k)           ! cat
                  cdata_all(25,iout)=var_jb(5,k)            ! non linear qc parameter
                  cdata_all(26,iout)=one                    ! hilbert curve weight, modified later 
+! H. ZHANG 20210113
+                 cdata_all(27,iout)=time_launch
+
                  if(perturb_obs)then
-                    cdata_all(27,iout)=ran01dom()*perturb_fact ! u perturbation
-                    cdata_all(28,iout)=ran01dom()*perturb_fact ! v perturbation
+                    cdata_all(28,iout)=ran01dom()*perturb_fact ! u perturbation
+                    cdata_all(29,iout)=ran01dom()*perturb_fact ! v perturbation
                  endif
+! H. ZHANG 20210113
  
               else if(spdob) then 
                  woe=obserr(5,k)
@@ -2297,7 +2318,10 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(18,iout)=r_prvstg(1,1)          ! provider name
                  cdata_all(19,iout)=r_sprvstg(1,1)         ! subprovider name
                  cdata_all(20,iout)=var_jb(1,k)            ! non linear qc b parameter 
-                 if(perturb_obs)cdata_all(21,iout)=ran01dom()*perturb_fact ! ps perturbation
+! H. ZHANG 20210113
+                 cdata_all(21,iout)=time_launch            ! sonde type data baloon launch time 
+                 if(perturb_obs)cdata_all(22,iout)=ran01dom()*perturb_fact ! ps perturbation
+! H. ZHANG 20210113
                  if (twodvar_regional) &
                     call adjust_error(cdata_all(14,iout),cdata_all(15,iout),cdata_all(11,iout),cdata_all(1,iout))
 
@@ -2340,7 +2364,11 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(21,iout)=r_sprvstg(1,1)         ! subprovider name
                  cdata_all(22,iout)=obsdat(10,k)           ! cat
                  cdata_all(23,iout)=var_jb(2,k)            ! non linear qc b parameter
-                 if(perturb_obs)cdata_all(24,iout)=ran01dom()*perturb_fact ! q perturbation
+!  H. ZHANG 20210113
+                 cdata_all(24,iout)=time_launch
+
+                 if(perturb_obs)cdata_all(25,iout)=ran01dom()*perturb_fact ! q perturbation
+!  H. ZHANG 20210113
                  if (twodvar_regional) &
                     call adjust_error(cdata_all(15,iout),cdata_all(16,iout),cdata_all(12,iout),cdata_all(1,iout))
  

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -383,7 +383,6 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   real(r_kind),allocatable,dimension(:) :: rlat_hil,rlon_hil,height,wtob,wght_hilb
 ! end of block
 
-! H. ZHANG 20210113
   real(r_kind) time_launch
 
 !  equivalence to handle character names
@@ -474,21 +473,15 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
             tcamtob .or. lcbasob .or. cldchob
   aircraftobst=.false.
   if(tob)then
-! H. ZHANG 20210113
-!    nreal=25
      nreal=26
   else if(uvob) then 
-!    nreal=26
      nreal=27
   else if(spdob) then
      nreal=24
   else if(psob) then
-!    nreal=20
      nreal=21
   else if(qob) then
-!    nreal=26
      nreal=27
-! H. ZHANG 20210113
   else if(pwob) then
      nreal=20
   else if(sstob) then
@@ -1828,7 +1821,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  endif
               end if
 
-              time_launch=-99999.0_r_kind ! H. ZHANG 20210113
+              time_launch=-99999.0_r_kind
 
 !             If needed, extract drift information.   
               if(driftl)then
@@ -1851,9 +1844,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  time_drift = timeobs + time_correction
                  if (abs(time_drift-time)>four) time_drift = time
  
-! H. ZHANG 20210113
                  time_launch=real(real(drfdat(3,1),r_single),r_double) + time_correction
-! H. ZHANG 20210113
 
 !                Check to see if the time is outside range
                  if (l4dvar.or.l4densvar) then
@@ -2108,14 +2099,12 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(23,iout)=r_sprvstg(1,1)         ! subprovider name
                  cdata_all(24,iout)=obsdat(10,k)           ! cat
                  cdata_all(25,iout)=var_jb(3,k)            ! non linear qc for T
-! H. ZHANG 20210113
                  cdata_all(26,iout)=time_launch
                  if (aircraft_t_bc_pof .or. aircraft_t_bc .or.aircraft_t_bc_ext) then
                     cdata_all(27,iout)=aircraftwk(1,k)     ! phase of flight
                     cdata_all(28,iout)=aircraftwk(2,k)     ! vertical velocity
                     cdata_all(29,iout)=idx                 ! index of temperature bias
                  end if
-! H. ZHANG 20210113
                  if(perturb_obs)cdata_all(nreal,iout)=ran01dom()*perturb_fact ! t perturbation
                  if (twodvar_regional) &
                     call adjust_error(cdata_all(17,iout),cdata_all(18,iout),cdata_all(11,iout),cdata_all(1,iout))
@@ -2244,14 +2233,12 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(24,iout)=obsdat(10,k)           ! cat
                  cdata_all(25,iout)=var_jb(5,k)            ! non linear qc parameter
                  cdata_all(26,iout)=one                    ! hilbert curve weight, modified later 
-! H. ZHANG 20210113
                  cdata_all(27,iout)=time_launch
 
                  if(perturb_obs)then
                     cdata_all(28,iout)=ran01dom()*perturb_fact ! u perturbation
                     cdata_all(29,iout)=ran01dom()*perturb_fact ! v perturbation
                  endif
-! H. ZHANG 20210113
  
               else if(spdob) then 
                  woe=obserr(5,k)
@@ -2318,10 +2305,8 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(18,iout)=r_prvstg(1,1)          ! provider name
                  cdata_all(19,iout)=r_sprvstg(1,1)         ! subprovider name
                  cdata_all(20,iout)=var_jb(1,k)            ! non linear qc b parameter 
-! H. ZHANG 20210113
                  cdata_all(21,iout)=time_launch            ! sonde type data baloon launch time 
                  if(perturb_obs)cdata_all(22,iout)=ran01dom()*perturb_fact ! ps perturbation
-! H. ZHANG 20210113
                  if (twodvar_regional) &
                     call adjust_error(cdata_all(14,iout),cdata_all(15,iout),cdata_all(11,iout),cdata_all(1,iout))
 
@@ -2364,11 +2349,9 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(21,iout)=r_sprvstg(1,1)         ! subprovider name
                  cdata_all(22,iout)=obsdat(10,k)           ! cat
                  cdata_all(23,iout)=var_jb(2,k)            ! non linear qc b parameter
-!  H. ZHANG 20210113
                  cdata_all(24,iout)=time_launch
 
                  if(perturb_obs)cdata_all(25,iout)=ran01dom()*perturb_fact ! q perturbation
-!  H. ZHANG 20210113
                  if (twodvar_regional) &
                     call adjust_error(cdata_all(15,iout),cdata_all(16,iout),cdata_all(12,iout),cdata_all(1,iout))
  

--- a/src/gsi/setupbend.f90
+++ b/src/gsi/setupbend.f90
@@ -142,7 +142,6 @@ subroutine setupbend(obsLL,odiagLL, &
 
   use gsi_4dvar, only: nobs_bins,hr_obsbin
   use guess_grids, only: ges_lnprsi,hrdifsig,geop_hgti,nfldsig
-  use guess_grids, only: ges_lnprsl,geop_hgtl,ges_tsen
   use guess_grids, only: nsig_ext,gpstop
   use gridmod, only: nsig
   use gridmod, only: get_ij,latlon11
@@ -259,8 +258,6 @@ subroutine setupbend(obsLL,odiagLL, &
   real(r_kind),allocatable,dimension(:,:,:  ) :: ges_z
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_tv
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_q 
-  real(r_kind),dimension(nsig,  nobs)         :: Tsen,Tvir,sphm,prslnl,hgtl
-  real(r_kind),dimension(nsig+1,nobs)         :: prslni, hgti
   integer,     dimension(nobs)                :: qcfail_8km
 
   type(obsLList),pointer,dimension(:):: gpshead
@@ -455,20 +452,6 @@ subroutine setupbend(obsLL,odiagLL, &
           mype,nfldsig)
 
      prsltmp_o(1:nsig,i)=prsltmp(1:nsig) ! needed in minimization
-
-!    Interpolate mid-level log(pres),mid-level geopotential height,
-!    and air temperature for JEDI
-     call tintrp2a1(ges_tsen,  Tsen(1:nsig,i),  dlat,dlon,dtime,hrdifsig, &
-                    nsig, mype,nfldsig)
-     call tintrp2a1(ges_lnprsl,prslnl(1:nsig,i),dlat,dlon,dtime,hrdifsig, &
-                    nsig, mype,nfldsig)
-     call tintrp2a1(geop_hgtl, hgtl(1:nsig,i),  dlat,dlon,dtime,hrdifsig, &
-                    nsig, mype,nfldsig)
-     sphm(1:nsig,i)      = qges(1:nsig)            ! specific humidity
-     prslni(1:nsig+1,i)  = prsltmp(1:nsig+1)       ! interface level log(pressure)
-     hgtl(1:nsig,i)      = hgtl(1:nsig,i) + zsges  ! mid level geopotential height
-     hgti(1:nsig+1,i)    = hges(1:nsig+1) + zsges  ! interface level geopotential height
-     Tvir(1:nsig,i)      = tges(1:nsig)            ! virtual temperature
 
 ! Compute refractivity index-radius product at interface
 !
@@ -1037,27 +1020,6 @@ subroutine setupbend(obsLL,odiagLL, &
         gps_alltail(ibin)%head%iob=ioid(i)
         gps_alltail(ibin)%head%elat= data(ilate,i)
         gps_alltail(ibin)%head%elon= data(ilone,i)
-
-!       2 dimensional geovals for JEDI
-        allocate(gps_alltail(ibin)%head%tsenges(nsig),stat=istatus)
-        allocate(gps_alltail(ibin)%head%tvirges(nsig),stat=istatus)
-        allocate(gps_alltail(ibin)%head%sphmges(nsig),stat=istatus)
-        allocate(gps_alltail(ibin)%head%prsiges(nsig),stat=istatus)
-        allocate(gps_alltail(ibin)%head%prslges(nsig),stat=istatus)
-        allocate(gps_alltail(ibin)%head%hgtlges(nsig),stat=istatus)
-        allocate(gps_alltail(ibin)%head%hgtiges(nsig+1),stat=istatus)
-
-        do j= 1, nsig
-          gps_alltail(ibin)%head%tsenges(j)  = Tsen(j,i)
-          gps_alltail(ibin)%head%tvirges(j)  = Tvir(j,i)
-          gps_alltail(ibin)%head%sphmges(j)  = sphm(j,i)
-          gps_alltail(ibin)%head%prslges(j)  = 1000.0*exp(prslnl(j,i))
-          gps_alltail(ibin)%head%hgtlges(j)  = hgtl(j,i)
-        end do
-        do j= 1, nsig + 1
-          gps_alltail(ibin)%head%prsiges(j)  = 1000.0*exp(prslni(j,i))
-          gps_alltail(ibin)%head%hgtiges(j)  = hgti(j,i)
-        end do
 
         allocate(gps_alltail(ibin)%head%rdiag(nreal),stat=istatus)
         if (istatus/=0) write(6,*)'SETUPBEND:  allocate error for gps_alldiag, istatus=',istatus

--- a/src/gsi/setupps.f90
+++ b/src/gsi/setupps.f90
@@ -211,6 +211,9 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   type(sparr2) :: dhx_dx
   integer(i_kind) :: ps_ind, nnz, nind
 
+! H. ZHANG 20210113
+  integer(i_kind) ::idft
+
   type(obsLList),pointer,dimension(:):: pshead
   pshead => obsLL(:)
 
@@ -242,7 +245,10 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   iprvd=18    ! index of observation provider
   isprvd=19   ! index of observation subprovider
   ijb=20      ! index of non linear qc parameter
-  iptrb=21    ! index of ps perturbation
+! H. ZHANG   20210113
+  idft=21     ! index of sonde profile launch time
+  iptrb=22    ! index of ps perturbation
+! H. ZHANG   20210113
 
 ! Declare local constants
   halfpi = half*pi
@@ -867,6 +873,9 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            call nc_diag_metadata("Pressure",                sngl(data(ipres,i)*r10))
            call nc_diag_metadata("Height",                  sngl(dhgt)             )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
+! H. ZHANG 20210113
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i)))
+! H. ZHANG 20210113
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
            call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )
            call nc_diag_metadata("Nonlinear_QC_Var_Jb",     sngl(var_jb)           )

--- a/src/gsi/setupps.f90
+++ b/src/gsi/setupps.f90
@@ -211,7 +211,6 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   type(sparr2) :: dhx_dx
   integer(i_kind) :: ps_ind, nnz, nind
 
-! H. ZHANG 20210113
   integer(i_kind) ::idft
 
   type(obsLList),pointer,dimension(:):: pshead
@@ -245,10 +244,8 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   iprvd=18    ! index of observation provider
   isprvd=19   ! index of observation subprovider
   ijb=20      ! index of non linear qc parameter
-! H. ZHANG   20210113
   idft=21     ! index of sonde profile launch time
   iptrb=22    ! index of ps perturbation
-! H. ZHANG   20210113
 
 ! Declare local constants
   halfpi = half*pi
@@ -873,9 +870,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            call nc_diag_metadata("Pressure",                sngl(data(ipres,i)*r10))
            call nc_diag_metadata("Height",                  sngl(dhgt)             )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
-! H. ZHANG 20210113
-           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i)))
-! H. ZHANG 20210113
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
            call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )
            call nc_diag_metadata("Nonlinear_QC_Var_Jb",     sngl(var_jb)           )

--- a/src/gsi/setupq.f90
+++ b/src/gsi/setupq.f90
@@ -263,6 +263,9 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) :: thispbl_height,ratio_PBL_height,prestsfc,diffsfc
   real(r_kind) :: hr_offset
 
+! H. ZHANG 20210113
+  integer(i_kind) :: idft
+
   equivalence(rstation_id,station_id)
   equivalence(r_prvstg,c_prvstg)
   equivalence(r_sprvstg,c_sprvstg)
@@ -312,7 +315,10 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   isprvd=21   ! index of observation subprovider
   icat =22    ! index of data level category
   ijb  =23    ! index of non linear qc parameter
-  iptrb=24    ! index of q perturbation
+  ! H. ZHANG    20210113
+  idft=24     ! index of sonde profile launch time
+  iptrb=25    ! index of q perturbation
+  ! H. ZHANG    20210113
 
   do i=1,nobs
      muse(i)=nint(data(iuse,i)) <= jiter
@@ -1192,6 +1198,9 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Pressure",                sngl(presq)            )
            call nc_diag_metadata("Height",                  sngl(data(iobshgt,i))  )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
+! H. ZHANG 20210113
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i)))
+! H. ZHANG 20210113
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
            call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )
            call nc_diag_metadata("Nonlinear_QC_Var_Jb",     sngl(var_jb)           )

--- a/src/gsi/setupq.f90
+++ b/src/gsi/setupq.f90
@@ -263,7 +263,6 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) :: thispbl_height,ratio_PBL_height,prestsfc,diffsfc
   real(r_kind) :: hr_offset
 
-! H. ZHANG 20210113
   integer(i_kind) :: idft
 
   equivalence(rstation_id,station_id)
@@ -315,10 +314,8 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   isprvd=21   ! index of observation subprovider
   icat =22    ! index of data level category
   ijb  =23    ! index of non linear qc parameter
-  ! H. ZHANG    20210113
   idft=24     ! index of sonde profile launch time
   iptrb=25    ! index of q perturbation
-  ! H. ZHANG    20210113
 
   do i=1,nobs
      muse(i)=nint(data(iuse,i)) <= jiter
@@ -1198,9 +1195,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Pressure",                sngl(presq)            )
            call nc_diag_metadata("Height",                  sngl(data(iobshgt,i))  )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
-! H. ZHANG 20210113
-           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i)))
-! H. ZHANG 20210113
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
            call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )
            call nc_diag_metadata("Nonlinear_QC_Var_Jb",     sngl(var_jb)           )

--- a/src/gsi/setupt.f90
+++ b/src/gsi/setupt.f90
@@ -317,6 +317,9 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) :: tges2m,qges2m,tges2m_water,qges2m_water
   real(r_kind) :: hr_offset
 
+! H. ZHANG 20210113
+  integer(i_kind) :: idft
+
   equivalence(rstation_id,station_id)
   equivalence(r_prvstg,c_prvstg)
   equivalence(r_sprvstg,c_sprvstg)
@@ -379,14 +382,18 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   isprvd=23   ! index of observation subprovider
   icat=24     ! index of data level category
   ijb=25      ! index of non linear qc parameter
+! H. ZHANG    20210113
+  idft=26     ! index of sonde profile launch time
+
   if (aircraft_t_bc_pof .or. aircraft_t_bc .or. aircraft_t_bc_ext) then
-     ipof=26     ! index of data pof
-     ivvlc=27    ! index of data vertical velocity
-     idx=28      ! index of tail number
-     iptrb=29    ! index of t perturbation
+     ipof=27     ! index of data pof
+     ivvlc=28    ! index of data vertical velocity
+     idx=29      ! index of tail number
+     iptrb=30    ! index of t perturbation
   else
-     iptrb=26    ! index of t perturbation
+     iptrb=27    ! index of t perturbation
   end if
+! H. ZHANG    20210113
 
   do i=1,nobs
      muse(i)=nint(data(iuse,i)) <= jiter
@@ -1601,6 +1608,9 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     call nc_diag_metadata("Pressure",                sngl(prest)            )
     call nc_diag_metadata("Height",                  sngl(data(iobshgt,i))  )
     call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
+! H. ZHANG 20210113
+    call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))  )
+! H. ZHANG 20210113
     call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
     call nc_diag_metadata("Setup_QC_Mark",           sngl(data(iqt,i))      )
     call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )

--- a/src/gsi/setupt.f90
+++ b/src/gsi/setupt.f90
@@ -317,7 +317,6 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) :: tges2m,qges2m,tges2m_water,qges2m_water
   real(r_kind) :: hr_offset
 
-! H. ZHANG 20210113
   integer(i_kind) :: idft
 
   equivalence(rstation_id,station_id)
@@ -382,7 +381,6 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   isprvd=23   ! index of observation subprovider
   icat=24     ! index of data level category
   ijb=25      ! index of non linear qc parameter
-! H. ZHANG    20210113
   idft=26     ! index of sonde profile launch time
 
   if (aircraft_t_bc_pof .or. aircraft_t_bc .or. aircraft_t_bc_ext) then
@@ -393,7 +391,6 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   else
      iptrb=27    ! index of t perturbation
   end if
-! H. ZHANG    20210113
 
   do i=1,nobs
      muse(i)=nint(data(iuse,i)) <= jiter
@@ -1608,9 +1605,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     call nc_diag_metadata("Pressure",                sngl(prest)            )
     call nc_diag_metadata("Height",                  sngl(data(iobshgt,i))  )
     call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
-! H. ZHANG 20210113
-    call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))  )
-! H. ZHANG 20210113
+    call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )
     call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
     call nc_diag_metadata("Setup_QC_Mark",           sngl(data(iqt,i))      )
     call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )

--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -319,6 +319,8 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) :: hr_offset
   real(r_kind) :: magomb
 
+! H. ZHANG 20210113
+  integer(i_kind) :: idft
 
   equivalence(rstation_id,station_id)
   equivalence(r_prvstg,c_prvstg)
@@ -375,9 +377,13 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   isprvd=23   ! index of observation subprovider
   icat=24     ! index of data level category
   ijb=25      ! index of non linear qc parameter
-  ihil=26     ! index of  hilbert curve weight
-  iptrbu=27   ! index of u perturbation
-  iptrbv=28   ! index of v perturbation
+! H. ZHANG   20210113
+  idft=26     ! index of sonde profile launch time
+
+  ihil=27     ! index of  hilbert curve weight
+  iptrbu=28   ! index of u perturbation
+  iptrbv=29   ! index of v perturbation
+! H. ZHANG   20210113
 
   mm1=mype+1
   scale=one
@@ -1749,6 +1755,9 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Pressure",                sngl(presw)            )
            call nc_diag_metadata("Height",                  sngl(data(ihgt,i))     )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
+! H. ZHANG 20210113
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i)))
+! H. ZHANG 20210113
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
 !           call nc_diag_metadata("Setup_QC_Mark",           rmiss_single           )
            call nc_diag_metadata("Setup_QC_Mark",           sngl(bmiss)            )

--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -319,7 +319,6 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) :: hr_offset
   real(r_kind) :: magomb
 
-! H. ZHANG 20210113
   integer(i_kind) :: idft
 
   equivalence(rstation_id,station_id)
@@ -377,13 +376,11 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   isprvd=23   ! index of observation subprovider
   icat=24     ! index of data level category
   ijb=25      ! index of non linear qc parameter
-! H. ZHANG   20210113
   idft=26     ! index of sonde profile launch time
 
   ihil=27     ! index of  hilbert curve weight
   iptrbu=28   ! index of u perturbation
   iptrbv=29   ! index of v perturbation
-! H. ZHANG   20210113
 
   mm1=mype+1
   scale=one
@@ -1755,9 +1752,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Pressure",                sngl(presw)            )
            call nc_diag_metadata("Height",                  sngl(data(ihgt,i))     )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
-! H. ZHANG 20210113
-           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i)))
-! H. ZHANG 20210113
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
 !           call nc_diag_metadata("Setup_QC_Mark",           rmiss_single           )
            call nc_diag_metadata("Setup_QC_Mark",           sngl(bmiss)            )


### PR DESCRIPTION
## Description

The earlier merged branch feature/jedi_gdas_gnssro_hailingz ran well on Cheyenne and S4, but has memory issue on Orion.
This PR removes the geovals writing to eliminate the memory issue. The geovals are not used for diagnosis and JEDI run.

What does it mean for this PR to be finished?
GSI can run on Orion to output necessary GNSSRO metadata and hofx for JEDI run and diagnostic (hofx comparison between JEDI and GSI)