### PR TITLE
To support month-long JEDI-GDAS experiment, alter the GSI variable outputs for GeoVaLs related to wind variables

### DIFF
--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -2233,11 +2233,14 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(24,iout)=obsdat(10,k)           ! cat
                  cdata_all(25,iout)=var_jb(5,k)            ! non linear qc parameter
                  cdata_all(26,iout)=one                    ! hilbert curve weight, modified later 
-                 cdata_all(27,iout)=time_launch
+                 cdata_all(27,iout)=time_launch            ! rawinsonde launch time
+                 cdata_all(28,iout)=hdrdat(9)              ! SWCM, spectral type 1-5
+                 cdata_all(29,iout)=hdrdat(10)             ! SAZA
+                 cdata_all(30,iout)=hdrdat(12)             ! SCCF, spectral wavenumber
 
                  if(perturb_obs)then
-                    cdata_all(28,iout)=ran01dom()*perturb_fact ! u perturbation
-                    cdata_all(29,iout)=ran01dom()*perturb_fact ! v perturbation
+                    cdata_all(31,iout)=ran01dom()*perturb_fact ! u perturbation
+                    cdata_all(32,iout)=ran01dom()*perturb_fact ! v perturbation
                  endif
  
               else if(spdob) then 

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -475,7 +475,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   if(tob)then
      nreal=26
   else if(uvob) then 
-     nreal=27
+     nreal=30
   else if(spdob) then
      nreal=24
   else if(psob) then

--- a/src/gsi/read_satwnd.f90
+++ b/src/gsi/read_satwnd.f90
@@ -266,7 +266,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 ! Set lower limits for observation errors
   werrmin=one
   nsattype=0
-  nreal=26
+  nreal=30
   if(perturb_obs ) nreal=nreal+2
   ntread=1
   ntmatch=0
@@ -1535,10 +1535,14 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
            cdata_all(23,iout)=r_sprvstg(1,1)      ! subprovider name
            cdata_all(25,iout)=var_jb              ! non linear qc parameter
            cdata_all(26,iout)=one                 ! hilbert curve weight 
+           cdata_all(27,iout)=time_launch         ! For rawinsonde launch
+           cdata_all(28,iout)=hdrdat(9)           ! SWCM, spectral type 1-5
+           cdata_all(29,iout)=hdrdat(10)          ! SAZA
+           cdata_all(30,iout)=hdrdat(12)          ! SCCF, spectral wavenumber
 
            if(perturb_obs)then
-              cdata_all(27,iout)=ran01dom()*perturb_fact ! u perturbation
-              cdata_all(28,iout)=ran01dom()*perturb_fact ! v perturbation
+              cdata_all(31,iout)=ran01dom()*perturb_fact ! u perturbation
+              cdata_all(32,iout)=ran01dom()*perturb_fact ! v perturbation
            endif
 
         enddo  loop_readsb

--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -287,7 +287,11 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   integer(i_kind) izz,iprvd,isprvd
   integer(i_kind) idomsfc,isfcr,iskint,iff10
   integer(i_kind) ibb,ikk,ihil
-  integer(i_kind) idft, iswcm, isaza, isccf
+
+  integer(i_kind) idft, iswcm, isaza, isccf, qify, qifn
+  real(r_kind)    sccf_wavelen
+  real(r_kind),parameter:: rsol=300000000.0_r_kind !speed of light
+  real(r_kind),parameter:: rtomic=1000000.0_r_kind !conv to micron
 
   integer(i_kind) num_bad_ikx
 
@@ -1906,7 +1910,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_data2d("northward_wind", sngl(vges))
            call nc_diag_data2d("air_temperature", sngl(tsentmp))
            call nc_diag_data2d("specific_humidity", sngl(qges))
-           call nc_diag_metadata("surface_temperature",sngl(skint))
+           call nc_diag_metadata("skin_temperature",sngl(skint))
            call nc_diag_metadata("surface_roughness", sngl(sfcr/r100))
            call nc_diag_metadata("landmask",sngl(msges))
            call nc_diag_metadata("Bias_Correction_Terms", sngl(bmiss))

--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -1830,20 +1830,23 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
              call nc_diag_metadata("SAZA_sat_zen_angle",      sngl(bmiss))
              call nc_diag_metadata("SCCF_chan_wavelen",       sngl(bmiss))
              call nc_diag_metadata("QI_with_FC",              sngl(bmiss))
-             call nc_diag_metadata("QI_without_FC",           sngl(bmiss)) 
+             call nc_diag_metadata("QI_without_FC",           sngl(bmiss))
            endif
 
            if (.not. regional .or. fv3_regional) then
               call nc_diag_metadata("u_Observation",                              sngl(data(iuob,i))    )
               call nc_diag_metadata("u_Obs_Minus_Forecast_adjusted",              sngl(dudiff)          )
               call nc_diag_metadata("u_Obs_Minus_Forecast_unadjusted",            sngl(uob-ugesin)      )
-
+              call nc_diag_metadata("u_Forecast_adjusted",                        sngl(data(iuob,i)-dudiff))
+              call nc_diag_metadata("u_Forecast_unadjusted",                      sngl(ugesin))
               call nc_diag_metadata("v_Observation",                              sngl(data(ivob,i))    )
               call nc_diag_metadata("v_Obs_Minus_Forecast_adjusted",              sngl(dvdiff)          )
               call nc_diag_metadata("v_Obs_Minus_Forecast_unadjusted",            sngl(vob-vgesin)      )
+              call nc_diag_metadata("v_Forecast_adjusted",                        sngl(data(ivob,i)-dvdiff))
+              call nc_diag_metadata("v_Forecast_unadjusted",                      sngl(vgesin))
            else ! (if regional)
 !              replace positions 17-22 with earth relative wind component information
-   
+
               uob_reg=data(iuob,i)
               vob_reg=data(ivob,i)
               dlon_e=data(ilone,i)*deg2rad
@@ -1854,10 +1857,14 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_metadata("u_Observation",                              sngl(uob_e)           )
               call nc_diag_metadata("u_Obs_Minus_Forecast_adjusted",              sngl(dudiff_e)        )
               call nc_diag_metadata("u_Obs_Minus_Forecast_unadjusted",            sngl(uob_e-uges_e)    )
+              call nc_diag_metadata("u_Forecast_adjusted", sngl(uob_e-dudiff_e))
+              call nc_diag_metadata("u_Forecast_unadjusted",sngl(uges_e))
 
               call nc_diag_metadata("v_Observation",                              sngl(vob_e)           )
               call nc_diag_metadata("v_Obs_Minus_Forecast_adjusted",              sngl(dvdiff_e)        )
               call nc_diag_metadata("v_Obs_Minus_Forecast_unadjusted",            sngl(vob_e-vges_e)    )
+              call nc_diag_metadata("v_Forecast_adjusted",                        sngl(vob_e-dvdiff_e))
+              call nc_diag_metadata("v_Forecast_unadjusted",                      sngl(vges_e))
            endif
 
            if (lobsdiagsave) then

--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -267,7 +267,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) oscat_vec,ascat_vec,rapidscat_vec
   real(r_kind),dimension(nele,nobs):: data
   real(r_kind),dimension(nobs):: dup
-  real(r_kind),dimension(nsig)::prsltmp,tsentmp,qtmp,tges,qges,zges
+  real(r_kind),dimension(nsig)::prsltmp,tsentmp,tges,qges,zges
   real(r_kind),dimension(nsig+1)::prsitmp
   real(r_kind) wdirob,wdirgesin,wdirdiffmax
   real(r_kind),dimension(34)::ptabluv
@@ -287,6 +287,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   integer(i_kind) izz,iprvd,isprvd
   integer(i_kind) idomsfc,isfcr,iskint,iff10
   integer(i_kind) ibb,ikk,ihil
+  integer(i_kind) idft, iswcm, isaza, isccf
 
   integer(i_kind) num_bad_ikx
 
@@ -378,8 +379,12 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   icat=24     ! index of data level category
   ijb=25      ! index of non linear qc parameter
   ihil=26     ! index of  hilbert curve weight
-  iptrbu=27   ! index of u perturbation
-  iptrbv=28   ! index of v perturbation
+  idft=27     ! index of sonde profile launch time
+  iswcm=28    ! index of SWCM, spectral type 1-5
+  isaza=29    ! index of solar zenith angle
+  isccf=30    ! index of spectral central frequency
+  iptrbu=31   ! index of u perturbation
+  iptrbv=32   ! index of v perturbation
 
   mm1=mype+1
   scale=one
@@ -546,7 +551,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
           nsig+1,mype,nfldsig)
      call tintrp2a1(ges_tsen,tsentmp,dlat,dlon,dtime,hrdifsig,&
           nsig,mype,nfldsig)
-     call tintrp2a1(ges_q,qtmp,dlat,dlon,dtime,hrdifsig,&
+     call tintrp2a1(ges_q,qges,dlat,dlon,dtime,hrdifsig,&
           nsig,mype,nfldsig)
      call tintrp2a1(ges_u,uges,dlat,dlon,dtime,hrdifsig,&
           nsig,mype,nfldsig)
@@ -1779,6 +1784,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Pressure",                sngl(presw)            )
            call nc_diag_metadata("Height",                  sngl(data(ihgt,i))     )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
 !           call nc_diag_metadata("Setup_QC_Mark",           rmiss_single           )
            call nc_diag_metadata("Setup_QC_Mark",           sngl(bmiss)            )
@@ -1891,9 +1897,8 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_data2d("geopotential_height", sngl(zges+zsges))
            call nc_diag_data2d("eastward_wind", sngl(uges))
            call nc_diag_data2d("northward_wind", sngl(vges))
-           call nc_diag_data2d("specific_humidity", sngl(qges))
            call nc_diag_data2d("air_temperature", sngl(tsentmp))
-           call nc_diag_data2d("specific_humidity", sngl(qtmp))
+           call nc_diag_data2d("specific_humidity", sngl(qges))
            call nc_diag_metadata("surface_temperature",sngl(skint))
            call nc_diag_metadata("surface_roughness", sngl(sfcr/r100))
            call nc_diag_metadata("landmask",sngl(msges))

--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -256,7 +256,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) cg_t,cvar,wgt,term,rat_err2,qcgross
   real(r_kind) presw,factw,dpres,ugesin,vgesin,rwgt,dpressave
   real(r_kind) sfcchk,prsln2,error,dtime,dlon,dlat,r0_001,rsig,thirty,rsigp
-  real(r_kind) ratio_errors,goverrd,spdges,spdob,ten,psges,zsges,uges,vges,q2ges
+  real(r_kind) ratio_errors,goverrd,spdges,spdob,ten,psges,zsges,uges,vges
   real(r_kind) slat,sin2,termg,termr,termrg,pobl,uob,vob
   real(r_kind) uob_reg,vob_reg,uob_e,vob_e,dlon_e,uges_e,vges_e,dudiff_e,dvdiff_e
   real(r_kind) dz,zob,z1,z2,p1,p2,dz21,dlnp21,spdb,dstn
@@ -332,7 +332,6 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_v
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_q
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_tv
-  real(r_kind),allocatable,dimension(:,:,:  ) :: ges_q2
 
   type(obsLList),pointer,dimension(:):: whead
   whead => obsLL(:)
@@ -1620,24 +1619,6 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
          write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
          call stop2(999)
      endif
-!    get q2m ...
-     varname='q2m'
-     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank2,istatus)
-     if (istatus==0) then
-         if(allocated(ges_q2))then
-            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
-            call stop2(999)
-         endif
-         allocate(ges_q2(size(rank2,1),size(rank2,2),nfldsig))
-         ges_q2(:,:,1)=rank2
-         do ifld=2,nfldsig
-            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank2,istatus)
-            ges_q2(:,:,ifld)=rank2
-         enddo
-     else
-         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
-         call stop2(999)
-     endif
   else
      write(6,*) trim(myname), ': inconsistent vector sizes (nfldsig,size(metguess_bundle) ',&
                  nfldsig,size(gsi_metguess_bundle)
@@ -1928,6 +1909,8 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("surface_temperature",sngl(skint))
            call nc_diag_metadata("surface_roughness", sngl(sfcr/r100))
            call nc_diag_metadata("landmask",sngl(msges))
+           call nc_diag_metadata("Bias_Correction_Terms", sngl(bmiss))
+           call nc_diag_metadata("Data_Pof", sngl(bmiss))
 
 
   end subroutine contents_netcdf_diag_
@@ -1939,7 +1922,6 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     if(allocated(ges_z )) deallocate(ges_z )
     if(allocated(ges_q )) deallocate(ges_q )
     if(allocated(ges_ps)) deallocate(ges_ps)
-    if(allocated(ges_q2)) deallocate(ges_q2)
   end subroutine final_vars_
 
 end subroutine setupw


### PR DESCRIPTION
## Description

In order to support the JEDI-GDAS testing, particularly for conventional data, we need GSI to output a unified set of common variables for use in GeoVaLs.  The changes to setupw.f90 (and read_prepbufr.f90 and read_satwnd.f90) add a bunch of non-wind variables to unify with other persons doing similarly in setupt, setupq, etc.

### Issue(s) addressed

No single issue was created for this.

## Acceptance Criteria (Definition of Done)

Reviewing of the ncdiag files for the correctness of all outputs.

## Dependencies

TBD - there will be other similar PRs for the other state variables (T, Q, ps)

## Impact

Impacts will be downstream in ioda-converters and python dictionary for some variable names to change.

## Test Data

None