### PR TITLE
Add JEDI geoval variables for radiance data

### DIFF
--- a/src/gsi/crtm_interface.f90
+++ b/src/gsi/crtm_interface.f90
@@ -359,7 +359,6 @@ subroutine init_crtm(init_pass,mype_diaghdr,mype,nchanl,nreal,isis,obstype,radmo
 ! ...all "additional absorber" variables
   integer(i_kind) :: j,icount
   integer(i_kind) :: ig
-  integer(i_kind) :: n_absorbers
   logical quiet
   logical print_verbose
 

--- a/src/gsi/crtm_interface.f90
+++ b/src/gsi/crtm_interface.f90
@@ -85,6 +85,7 @@ public call_crtm            ! Subroutine creates profile for crtm, calls crtm, t
 public destroy_crtm         ! Subroutine destroys initialization for crtm
 public sensorindex
 public surface
+public atmosphere          
 public isatid               ! = 1  index of satellite id
 public itime                ! = 2  index of analysis relative obs time
 public ilon                 ! = 3  index of grid relative obs location (x)
@@ -125,6 +126,8 @@ public itref                ! = 34/36 index of Tr
 public idtw                 ! = 35/37 index of d(Tw)
 public idtc                 ! = 36/38 index of d(Tc)
 public itz_tr               ! = 37/39 index of d(Tz)/d(Tr)
+public n_clouds_fwd_wk
+public n_absorbers
 
 ! For TMI and GMI
 public iedge_log            ! = 32  ! index, if obs is to be obleted beause of locating near scan edges.
@@ -203,6 +206,7 @@ public isazi_ang2           ! = 37 index of solar azimuth angle (degrees)
   logical        ,save :: lprecip_wk 
   logical        ,save :: mixed_use
   integer(i_kind), parameter :: min_n_absorbers = 2
+  integer(i_kind) :: n_absorbers
 
   integer(i_kind),save :: iedge_log
   integer(i_kind),save :: ilzen_ang2,ilazi_ang2,iscan_ang2,iszen_ang2,isazi_ang2

--- a/src/gsi/setuprad.f90
+++ b/src/gsi/setuprad.f90
@@ -2579,6 +2579,8 @@ contains
                  call nc_diag_metadata("Observation",                           sngl(tb_obs0(ich_diag(i))) )    ! observed brightness temperature (K)
                  call nc_diag_metadata("Obs_Minus_Forecast_unadjusted",         sngl(tbcnob(ich_diag(i)))  )    ! observed - simulated Tb with no bias correction (K)
                  call nc_diag_metadata("Obs_Minus_Forecast_adjusted",           sngl(tbc0(ich_diag(i)  ))  )    ! observed - simulated Tb with bias corrrection (K)
+                 call nc_diag_metadata("Forecast_unadjusted", sngl(tb_obs(ich_diag(i))-tbcnob(ich_diag(i)))) ! simulated Tb with no bias correction
+                 call nc_diag_metadata("Forecast_adjusted",   sngl(tb_obs(ich_diag(i))-tbc(ich_diag(i))))    ! simulated Tb with bias correction
                  errinv = sqrt(varinv0(ich_diag(i)))
                  call nc_diag_metadata("Inverse_Observation_Error",             sngl(errinv)          )
                  call nc_diag_metadata("Input_Observation_Error",          sngl(error0(ich_diag(i)))  )         ! observed brightness temperature (K)

--- a/src/gsi/setuprad.f90
+++ b/src/gsi/setuprad.f90
@@ -279,10 +279,10 @@ contains
   use sst_retrieval, only: setup_sst_retrieval,avhrr_sst_retrieval,&
       finish_sst_retrieval,spline_cub
   use m_dtime, only: dtime_setup, dtime_check
-  use crtm_interface, only: init_crtm,call_crtm,destroy_crtm,sensorindex,surface, &
+  use crtm_interface, only: init_crtm,call_crtm,destroy_crtm,sensorindex,surface,atmosphere, &
       itime,ilon,ilat,ilzen_ang,ilazi_ang,iscan_ang,iscan_pos,iszen_ang,isazi_ang, &
       ifrac_sea,ifrac_lnd,ifrac_ice,ifrac_sno,itsavg, &
-      izz,idomsfc,isfcr,iff10,ilone,ilate, &
+      izz,idomsfc,isfcr,iff10,ilone,ilate,n_clouds_fwd_wk,n_absorbers, &
       isst_hires,isst_navy,idata_type,iclr_sky,itref,idtw,idtc,itz_tr
   use qcmod, only: qc_ssmi,qc_geocsr,qc_ssu,qc_avhrr,qc_goesimg,qc_msu,qc_irsnd,qc_amsua,qc_mhs,qc_atms
   use crtm_interface, only: ilzen_ang2,iscan_ang2,iszen_ang2,isazi_ang2
@@ -2487,6 +2487,9 @@ contains
   real(r_single),parameter::  missing = -9.99e9_r_single
   integer(i_kind),parameter:: imissing = -999999
   real(r_kind),dimension(:),allocatable :: predbias_angord
+  character(128) :: fieldname
+  integer(i_kind) :: iabsorb, icloud
+
 
   if (adp_anglebc) then
     allocate(predbias_angord(angord) )
@@ -2524,7 +2527,7 @@ contains
                     call nc_diag_metadata("Soil_Temperature",      sngl(surface(1)%soil_temperature)  ) ! soil temperature (K)
                     call nc_diag_metadata("Soil_Moisture",         sngl(surface(1)%soil_moisture_content) ) ! soil moisture
                     call nc_diag_metadata("Land_Type_Index",       surface(1)%land_type             ) ! surface land type
-                    call nc_diag_metadata("tsavg5",                missing                          ) ! SST first guess used for SST retrieval
+                    call nc_diag_metadata("tsavg5",                sngl(tsavg5)                     ) ! SST first guess used for SST retrieval
                     call nc_diag_metadata("sstcu",                 missing                          ) ! NCEP SST analysis at t            
                     call nc_diag_metadata("sstph",                 missing                          ) ! Physical SST retrieval             
                     call nc_diag_metadata("sstnv",                 missing                          ) ! Navy SST retrieval               
@@ -2573,13 +2576,14 @@ contains
                  call nc_diag_metadata("SST_Cool_layer_tdrop",     sngl(data_s(idtc,n))              )       ! dt_cool at zob
                  call nc_diag_metadata("SST_dTz_dTfound",          sngl(data_s(itz_tr,n))            )       ! d(Tz)/d(Tr)
 
-                 call nc_diag_metadata("Observation",                           sngl(tb_obs0(ich_diag(i)))  )     ! observed brightness temperature (K)
-                 call nc_diag_metadata("Obs_Minus_Forecast_unadjusted",         sngl(tbcnob(ich_diag(i)))  )     ! observed - simulated Tb with no bias correction (K)
-                 call nc_diag_metadata("Obs_Minus_Forecast_adjusted",           sngl(tbc0(ich_diag(i)  ))  )     ! observed - simulated Tb with bias corrrection (K)
+                 call nc_diag_metadata("Observation",                           sngl(tb_obs0(ich_diag(i))) )    ! observed brightness temperature (K)
+                 call nc_diag_metadata("Obs_Minus_Forecast_unadjusted",         sngl(tbcnob(ich_diag(i)))  )    ! observed - simulated Tb with no bias correction (K)
+                 call nc_diag_metadata("Obs_Minus_Forecast_adjusted",           sngl(tbc0(ich_diag(i)  ))  )    ! observed - simulated Tb with bias corrrection (K)
                  errinv = sqrt(varinv0(ich_diag(i)))
                  call nc_diag_metadata("Inverse_Observation_Error",             sngl(errinv)          )
+                 call nc_diag_metadata("Input_Observation_Error",          sngl(error0(ich_diag(i)))  )         ! observed brightness temperature (K)
                  if (save_jacobian .and. allocated(idnames)) then
-                 call nc_diag_metadata("Observation_scaled",                    sngl(tb_obs(ich_diag(i)))  )     ! observed brightness temperature (K) scaled by R^{-1/2}
+                 call nc_diag_metadata("Observation_scaled",                    sngl(tb_obs(ich_diag(i))) )     ! observed brightness temperature (K) scaled by R^{-1/2}
                  call nc_diag_metadata("Obs_Minus_Forecast_adjusted_scaled",    sngl(tbc(ich_diag(i)  ))  )     ! observed - simulated Tb with bias corrrection (K) scaled by R^{-1/2}
                  errinv = sqrt(varinv(ich_diag(i)))
                  call nc_diag_metadata("Inverse_Observation_Error_scaled",      sngl(errinv)          )
@@ -2662,7 +2666,31 @@ contains
                        call nc_diag_data2d("BCPred_angord",   sngl(predbias_angord)                                )
                     endif
                  end if
+                 ! GeoVaLs for JEDI/UFO
+                 ! Get GeoVaLs for surface 
+                 call nc_diag_metadata("Vegetation_Type", sngl(surface(1)%vegetation_type)  )
+                 call nc_diag_metadata("Lai", sngl(surface(1)%lai)                          )
+                 call nc_diag_metadata("Soil_Type", sngl(surface(1)%soil_type)              )
+                 call nc_diag_metadata("Sfc_Wind_Direction", sngl(surface(1)%wind_direction))
+                 call nc_diag_metadata("Sfc_Height",         sngl(zsges    )                ) ! do we need this for geoval? I think we do not
 
+                 ! Get GeoVaLs for atmosphere
+                 call nc_diag_data2d("air_temperature", sngl(atmosphere(1)%temperature)            )   ! K 
+                 call nc_diag_data2d("air_pressure", sngl(atmosphere(1)%pressure*r100)             )
+                 call nc_diag_data2d("air_pressure_levels", sngl(atmosphere(1)%level_pressure*r100))
+
+                 ! Get GeoVaLs for atmospheric absorbers
+                 do iabsorb = 1, n_absorbers
+                   write (fieldname, "(A,I0.2)") "atmosphere_absorber_", atmosphere(1)%absorber_id(iabsorb)
+                   call nc_diag_data2d(trim(fieldname), sngl(atmosphere(1)%absorber(:,iabsorb)))   ! check %absorber_units
+                 enddo
+                 ! Get GeoVaLs for hydrometeors 
+                 do icloud = 1, n_clouds_fwd_wk
+                   write (fieldname, "(A,I0.2)") "atmosphere_mass_content_of_cloud_", atmosphere(1)%Cloud(icloud)%Type
+                   call nc_diag_data2d(trim(fieldname), sngl(atmosphere(1)%Cloud(icloud)%Water_Content))
+                   write (fieldname, "(A,I0.2)") "effective_radius_of_cloud_particle_", atmosphere(1)%Cloud(icloud)%Type
+                   call nc_diag_data2d(trim(fieldname), sngl(atmosphere(1)%Cloud(icloud)%Effective_Radius))
+                 enddo
               enddo
 !  if (adp_anglebc) then
   if (.true.) then


### PR DESCRIPTION
## Description

The following two types of variables are added:
(1) geoval variables required by CRTM
(2) Input observation error --- In the current UFO for clear-sky radiance assimilation, the input observation error (originally specified in GSI satinfo) is read from IODA file. This will be changed in the near future.

