### PR TITLE
Add JEDI geoval variables for ozone data

### DIFF
--- a/src/gsi/setupoz.f90
+++ b/src/gsi/setupoz.f90
@@ -113,7 +113,7 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
   use state_vectors, only: svars3d, levels
 
   use constants, only : zero,half,one,two,tiny_r_kind
-  use constants, only : rozcon,cg_term,wgtlim,h300,r10
+  use constants, only : rozcon,cg_term,wgtlim,h300,r10,r100,r1000,constoz !emily
 
   use m_obsdiagNode, only : obs_diag
   use m_obsdiagNode, only : obs_diags
@@ -201,6 +201,7 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
   real(r_kind),dimension(nlevs):: pobs,gross,tnoise
   real(r_kind),dimension(nreal+nlevs,nobs):: data
   real(r_kind),dimension(nsig+1)::prsitmp
+  real(r_kind),dimension(nsig)::ozgestmp  !emily
   real(r_single),dimension(nlevs):: pob4,grs4,err4
   real(r_single),dimension(ireal,nobs):: diagbuf
   real(r_single),allocatable,dimension(:,:,:)::rdiagbuf
@@ -214,7 +215,7 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
   type(sparr2) :: dhx_dx
 
   integer(i_kind) i,nlev,ii,jj,iextra,ibin, kk, nperobs
-  integer(i_kind) k,j,nz,jc,idia,irdim1,istatus,ioff0
+  integer(i_kind) k1,k2,k,j,nz,jc,idia,irdim1,istatus,ioff0  !emily
   integer(i_kind) ioff,itoss,ikeep,ierror_toq,ierror_poq
   integer(i_kind) isolz,ifovn,itoqf
   integer(i_kind) mm1,itime,ilat,ilon,ilate,ilone,itoq,ipoq
@@ -387,7 +388,7 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
               call grdcrd1(ozp(nz),prsitmp,nsig+1,-1)
            enddo
         end if
-       
+ 
         if (obstype == 'omieff' .or. obstype == 'tomseff') then
            pob_oz_omi(nloz_omi) = 1000.0_r_kind* 1.01325_r_kind
            do j=nloz_omi-1, 1, -1
@@ -415,7 +416,13 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
                 nlevs,mype,doz_dz)
         endif
 
-        
+!>>emily     
+        call tintrp2a1(ges_oz,ozgestmp,dlat,dlon,dtime,hrdifsig,&
+             nsig,mype,nfldsig)
+
+        call tintrp2a1(ges_prsi, prsitmp,dlat,dlon,dtime,hrdifsig,&
+             nsig+1,mype,nfldsig)
+!<<emily     
 
         if(ozone_diagsave .and. luse(i))then
            ii=ii+1
@@ -565,14 +572,36 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
               endif
 
               if (netcdf_diag) then
+!>>emily
+                 k1 = k
+                 k2 = k - 1
+                 if(k2 == 0)k2 = 1
+                 if(k == nlevs)then
+                   k1=nlevs-1
+                   k2=1
+                 endif
+                 if (obstype == 'sbuv2' .or. obstype == 'ompsnp' ) then
+                    call nc_diag_metadata("TopLevelPressure",sngl(pobs(k2)*r100))
+                    call nc_diag_metadata("BottomLevelPressure", & sngl(pobs(k1)*r100))
+                 else
+                    call nc_diag_metadata("TopLevelPressure",sngl(prsitmp(nsig+1)*r1000) )
+                    call nc_diag_metadata("BottomLevelPressure", sngl(prsitmp(1)*r1000) )
+                  endif
+                 
+                 call nc_diag_metadata("TopLevelPressure",sngl(pobs(k2)*r100))
+                 call nc_diag_metadata("BottomLevelPressure", sngl(pobs(k1)*r100))
+!<<emily
                  call nc_diag_metadata("MPI_Task_Number", mype                      )
                  call nc_diag_metadata("Latitude",        sngl(data(ilate,i))       )
                  call nc_diag_metadata("Longitude",       sngl(data(ilone,i))       )
                  call nc_diag_metadata("Time",            sngl(data(itime,i)-time_offset) )
-                 call nc_diag_metadata("Reference_Pressure",     sngl(pobs(k))      )
+                 call nc_diag_metadata("Total_Ozone_Error_Flag", sngl(ierror_toq ))          !emily_test
+                 call nc_diag_metadata("Profile_Ozone_Error_Flag", sngl(ierror_poq ))        !emily_test
+                 call nc_diag_metadata("Reference_Pressure",     sngl(pobs(k)*r100)      )   !emily
                  call nc_diag_metadata("Analysis_Use_Flag",      iouse(k)           )
                  call nc_diag_metadata("Observation",                  sngl(ozobs(k)))
                  call nc_diag_metadata("Inverse_Observation_Error",    sngl(errorinv))
+                 call nc_diag_metadata("Input_Observation_Error",      sngl(error(k)))       !emily
                  call nc_diag_metadata("Obs_Minus_Forecast_adjusted",  sngl(ozone_inv(k)))
                  call nc_diag_metadata("Obs_Minus_Forecast_unadjusted",sngl(ozone_inv(k)))
                  if (obstype == 'gome' .or. obstype == 'omieff'  .or. &
@@ -593,6 +622,10 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
                    call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
                    call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
                  endif
+!>>emily
+                call nc_diag_data2d("mole_fraction_of_ozone_in_air", sngl(ozgestmp*constoz))
+                call nc_diag_data2d("air_pressure_levels",sngl(prsitmp*r1000))
+!<<emily
               endif
            endif
 

--- a/src/gsi/setupoz.f90
+++ b/src/gsi/setupoz.f90
@@ -113,7 +113,7 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
   use state_vectors, only: svars3d, levels
 
   use constants, only : zero,half,one,two,tiny_r_kind
-  use constants, only : rozcon,cg_term,wgtlim,h300,r10,r100,r1000,constoz !emily
+  use constants, only : rozcon,cg_term,wgtlim,h300,r10,r100,r1000,constoz
 
   use m_obsdiagNode, only : obs_diag
   use m_obsdiagNode, only : obs_diags
@@ -201,7 +201,7 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
   real(r_kind),dimension(nlevs):: pobs,gross,tnoise
   real(r_kind),dimension(nreal+nlevs,nobs):: data
   real(r_kind),dimension(nsig+1)::prsitmp
-  real(r_kind),dimension(nsig)::ozgestmp  !emily
+  real(r_kind),dimension(nsig)::ozgestmp
   real(r_single),dimension(nlevs):: pob4,grs4,err4
   real(r_single),dimension(ireal,nobs):: diagbuf
   real(r_single),allocatable,dimension(:,:,:)::rdiagbuf
@@ -215,7 +215,7 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
   type(sparr2) :: dhx_dx
 
   integer(i_kind) i,nlev,ii,jj,iextra,ibin, kk, nperobs
-  integer(i_kind) k1,k2,k,j,nz,jc,idia,irdim1,istatus,ioff0  !emily
+  integer(i_kind) k1,k2,k,j,nz,jc,idia,irdim1,istatus,ioff0
   integer(i_kind) ioff,itoss,ikeep,ierror_toq,ierror_poq
   integer(i_kind) isolz,ifovn,itoqf
   integer(i_kind) mm1,itime,ilat,ilon,ilate,ilone,itoq,ipoq
@@ -416,13 +416,11 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
                 nlevs,mype,doz_dz)
         endif
 
-!>>emily     
         call tintrp2a1(ges_oz,ozgestmp,dlat,dlon,dtime,hrdifsig,&
              nsig,mype,nfldsig)
 
         call tintrp2a1(ges_prsi, prsitmp,dlat,dlon,dtime,hrdifsig,&
              nsig+1,mype,nfldsig)
-!<<emily     
 
         if(ozone_diagsave .and. luse(i))then
            ii=ii+1
@@ -572,7 +570,6 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
               endif
 
               if (netcdf_diag) then
-!>>emily
                  k1 = k
                  k2 = k - 1
                  if(k2 == 0)k2 = 1
@@ -586,24 +583,22 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
                  else
                     call nc_diag_metadata("TopLevelPressure",sngl(prsitmp(nsig+1)*r1000) )
                     call nc_diag_metadata("BottomLevelPressure", sngl(prsitmp(1)*r1000) )
-                  endif
-                 
-                 call nc_diag_metadata("TopLevelPressure",sngl(pobs(k2)*r100))
-                 call nc_diag_metadata("BottomLevelPressure", sngl(pobs(k1)*r100))
-!<<emily
+                 endif
                  call nc_diag_metadata("MPI_Task_Number", mype                      )
                  call nc_diag_metadata("Latitude",        sngl(data(ilate,i))       )
                  call nc_diag_metadata("Longitude",       sngl(data(ilone,i))       )
                  call nc_diag_metadata("Time",            sngl(data(itime,i)-time_offset) )
-                 call nc_diag_metadata("Total_Ozone_Error_Flag", sngl(ierror_toq ))          !emily_test
-                 call nc_diag_metadata("Profile_Ozone_Error_Flag", sngl(ierror_poq ))        !emily_test
-                 call nc_diag_metadata("Reference_Pressure",     sngl(pobs(k)*r100)      )   !emily
+                 call nc_diag_metadata("Total_Ozone_Error_Flag", sngl(ierror_toq ))
+                 call nc_diag_metadata("Profile_Ozone_Error_Flag", sngl(ierror_poq ))
+                 call nc_diag_metadata("Reference_Pressure",     sngl(pobs(k)*r100)      )
                  call nc_diag_metadata("Analysis_Use_Flag",      iouse(k)           )
                  call nc_diag_metadata("Observation",                  sngl(ozobs(k)))
                  call nc_diag_metadata("Inverse_Observation_Error",    sngl(errorinv))
-                 call nc_diag_metadata("Input_Observation_Error",      sngl(error(k)))       !emily
+                 call nc_diag_metadata("Input_Observation_Error",      sngl(error(k)))
                  call nc_diag_metadata("Obs_Minus_Forecast_adjusted",  sngl(ozone_inv(k)))
                  call nc_diag_metadata("Obs_Minus_Forecast_unadjusted",sngl(ozone_inv(k)))
+                 call nc_diag_metadata("Forecast_unadjusted", sngl(ozges(k)))
+                 call nc_diag_metadata("Forecast_adjusted",sngl(ozges(k)))       
                  if (obstype == 'gome' .or. obstype == 'omieff'  .or. &
                      obstype == 'omi'  .or. obstype == 'tomseff' ) then
                     call nc_diag_metadata("Solar_Zenith_Angle", sngl(data(isolz,i)) )
@@ -622,10 +617,8 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
                    call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
                    call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
                  endif
-!>>emily
                 call nc_diag_data2d("mole_fraction_of_ozone_in_air", sngl(ozgestmp*constoz))
                 call nc_diag_data2d("air_pressure_levels",sngl(prsitmp*r1000))
-!<<emily
               endif
            endif
 


### PR DESCRIPTION
The following two types of variables are added:
(1) geoval variables required by JEDI for ozone data
(2) ozone observation QC flag (from data provider)